### PR TITLE
Add simple example for `ArrayReader`

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,0 +1,19 @@
+use io_arrays::{ArrayReader, ReadAt};
+use io_streams::StreamWriter;
+use std::io::copy;
+
+fn main() -> anyhow::Result<()> {
+    let reader = ArrayReader::bytes(b"123hello world456")?;
+
+    // Start at offset 3 and read 11 bytes from input.
+    let mut buf = vec![0_u8; 11];
+    reader.read_exact_at(&mut buf, 3)?;
+    // The buffer can be used directly.
+    // println!("{}", std::str::from_utf8(&buf)?);
+
+    // Or it can be transformed into a stream.
+    let mut stream = ArrayReader::bytes(&buf)?.read_via_stream_at(0)?;
+    let mut stdout = StreamWriter::stdout()?;
+    copy(&mut stream, &mut stdout)?;
+    Ok(())
+}


### PR DESCRIPTION
This commit adds a simple example that seeks an array, reads a number of
bytes, transforms the resulting buffer into a stream, which is then
copied to standard output using a `StreamWriter`.
